### PR TITLE
feat: allow players to spawn yellow particles

### DIFF
--- a/scpsl/scpsl/Commands/PlayerParticleTextCommand.cs
+++ b/scpsl/scpsl/Commands/PlayerParticleTextCommand.cs
@@ -1,0 +1,47 @@
+using CommandSystem;
+using Exiled.API.Features;
+using Exiled.API.Features.Toys;
+using Exiled.API.Structs;
+using AdminToys;
+using System;
+using UnityEngine;
+
+namespace scpsl.Commands
+{
+    [CommandHandler(typeof(ClientCommandHandler))]
+    public class PlayerParticleTextCommand : ICommand
+    {
+        public string Command => "pwrite";
+        public string[] Aliases => Array.Empty<string>();
+        public string Description => "Создаёт жёлтую частицу там, куда смотрит игрок";
+        public bool SanitizeResponse => false;
+
+        public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
+        {
+            if (sender is not Player player)
+            {
+                response = "Команду можно использовать только в игре.";
+                return false;
+            }
+
+            var position = player.CameraTransform.position + player.CameraTransform.forward * 2f;
+
+            var settings = new PrimitiveSettings
+            {
+                PrimitiveType = PrimitiveType.Sphere,
+                Flags = PrimitiveFlags.None,
+                Color = Color.yellow,
+                Position = position,
+                Rotation = Quaternion.identity,
+                Scale = Vector3.one * 0.2f,
+                IsStatic = true,
+                ShouldSpawn = true,
+            };
+
+            Primitive.Create(settings);
+
+            response = "Частица создана.";
+            return true;
+        }
+    }
+}

--- a/scpsl/scpsl/scpsl.csproj
+++ b/scpsl/scpsl/scpsl.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="EXILED" Version="9.0.0-alpha.1" />
+    <PackageReference Include="UnityEngine.CoreModule" Version="2020.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add `pwrite` command that lets players spawn yellow particle spheres where they look
- reference UnityEngine.CoreModule in project file

## Testing
- `dotnet build scpsl/scpsl/scpsl.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68a0dde87d5c8327a33f488dd74d6c9a